### PR TITLE
Add gcompat package to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bundle exec bootsnap precompile app/ lib/
 FROM ruby:$RUBY_VERSION-alpine
 
 # Install runtime dependencies
-RUN apk add --no-cache curl jemalloc sqlite-libs vips tzdata
+RUN apk add --no-cache curl gcompat jemalloc sqlite-libs vips tzdata
 
 ENV RAILS_ENV="production" \
     RAILS_ROOT="/app" \


### PR DESCRIPTION
fixes runtime issue `Error loading shared library ld-linux-aarch64.so.1: No such file or directory`