### PR TITLE
Fix flaky OIDC test

### DIFF
--- a/app/lib/clients/vault/entity_alias.rb
+++ b/app/lib/clients/vault/entity_alias.rb
@@ -40,7 +40,7 @@ module Clients
 
       private
       def find_alias(aliases, name, auth_path)
-        aliases.find { |a| a[:name] == name && a[:mount_path] == "auth/#{auth_path}/"}
+        aliases.find { |a| a[:name] == name && a[:mount_path] == "auth/#{auth_path}/" }
       end
     end
   end

--- a/app/lib/clients/vault/entity_alias.rb
+++ b/app/lib/clients/vault/entity_alias.rb
@@ -1,13 +1,13 @@
 module Clients
   class Vault
     module EntityAlias
-      def put_entity_alias(entity_name, alias_name, auth_method)
+      def put_entity_alias(entity_name, alias_name, auth_path)
         e = read_entity(entity_name)
         if e.nil?
           raise "no such entity #{entity_name}"
         end
         canonical_id = e.data[:id]
-        auth_sym = "#{auth_method}/".to_sym
+        auth_sym = "#{auth_path}/".to_sym
         accessor = client.logical.read("/sys/auth").data[auth_sym][:accessor]
         client.logical.write("identity/entity-alias",
                              name: alias_name,
@@ -15,27 +15,32 @@ module Clients
                              mount_accessor: accessor)
       end
 
-      def read_entity_alias_id(entity_name, alias_name)
+      def read_entity_alias_id(entity_name, alias_name, auth_path)
         e = read_entity(entity_name)
         if e.nil?
           raise "no such entity #{entity_name}"
         end
         aliases = e.data[:aliases]
-        a = aliases.find { |a| a[:name] == alias_name }
+        a = find_alias(aliases, alias_name, auth_path)
         if a.nil?
           raise "no such alias #{alias_name}"
         end
         a[:id]
       end
 
-      def read_entity_alias(entity_name, alias_name)
-        id = read_entity_alias_id(entity_name, alias_name)
+      def read_entity_alias(entity_name, alias_name, auth_path)
+        id = read_entity_alias_id(entity_name, alias_name, auth_path)
         client.logical.read("identity/entity-alias/id/#{id}")
       end
 
-      def delete_entity_alias(entity_name, alias_name)
-        id = read_entity_alias_id(entity_name, alias_name)
+      def delete_entity_alias(entity_name, alias_name, auth_path)
+        id = read_entity_alias_id(entity_name, alias_name, auth_path)
         client.logical.delete("identity/entity-alias/id/#{id}")
+      end
+
+      private
+      def find_alias(aliases, name, auth_path)
+        aliases.find { |a| a[:name] == name && a[:mount_path] == "auth/#{auth_path}/"}
       end
     end
   end

--- a/config/astral.yml
+++ b/config/astral.yml
@@ -55,7 +55,7 @@ shared:
 
   initial_user_name: test
   initial_user_password: test
-  initial_user_email: john.doe@example.com
+  initial_user_email: test2024@example.com
 
 test:
   cert_ttl: <%= 24.hours.in_seconds %>

--- a/test/lib/clients/vault_test.rb
+++ b/test/lib/clients/vault_test.rb
@@ -120,28 +120,28 @@ class VaultTest < ActiveSupport::TestCase
 
   test "entity_alias methods" do
     # confirm no entity yet
+    auth_path = "token"
     err = assert_raises RuntimeError do
-      @client.read_entity_alias(@entity_name, @alias_name)
+      @client.read_entity_alias(@entity_name, @alias_name, auth_path)
     end
     assert_match /no such entity/, err.message
 
     # confirm no alias yet
     @client.put_entity(@entity_name, @policies)
     err = assert_raises RuntimeError do
-      @client.read_entity_alias(@entity_name, @alias_name)
+      @client.read_entity_alias(@entity_name, @alias_name, auth_path)
     end
     assert_match /no such alias/, err.message
 
     # create alias
-    auth_method = "token"
-    @client.put_entity_alias(@entity_name, @alias_name, auth_method)
-    entity_alias =  @client.read_entity_alias(@entity_name, @alias_name)
-    assert_equal auth_method, entity_alias.data[:mount_type]
+    @client.put_entity_alias(@entity_name, @alias_name, auth_path)
+    entity_alias =  @client.read_entity_alias(@entity_name, @alias_name, auth_path)
+    assert_equal auth_path, entity_alias.data[:mount_type]
 
     # confirm deleted alias
-    assert_equal true, @client.delete_entity_alias(@entity_name, @alias_name)
+    assert_equal true, @client.delete_entity_alias(@entity_name, @alias_name, auth_path)
     err = assert_raises RuntimeError do
-      @client.delete_entity_alias(@entity_name, @alias_name)
+      @client.delete_entity_alias(@entity_name, @alias_name, auth_path)
     end
     assert_match /no such alias/, err.message
   end

--- a/test/lib/clients/vault_test.rb
+++ b/test/lib/clients/vault_test.rb
@@ -133,10 +133,21 @@ class VaultTest < ActiveSupport::TestCase
     end
     assert_match /no such alias/, err.message
 
-    # create alias
+    # create token alias
     @client.put_entity_alias(@entity_name, @alias_name, auth_path)
     entity_alias =  @client.read_entity_alias(@entity_name, @alias_name, auth_path)
     assert_equal auth_path, entity_alias.data[:mount_type]
+
+    # create different alias type with same name
+    oidc_path = "oidc"
+    @client.put_entity_alias(@entity_name, @alias_name, oidc_path)
+    entity_alias =  @client.read_entity_alias(@entity_name, @alias_name, oidc_path)
+    assert_equal oidc_path, entity_alias.data[:mount_type]
+
+
+    # confirm two aliases
+    entity =  @client.read_entity(@entity_name)
+    assert_equal 2, entity.data[:aliases].size
 
     # confirm deleted alias
     assert_equal true, @client.delete_entity_alias(@entity_name, @alias_name, auth_path)
@@ -144,6 +155,10 @@ class VaultTest < ActiveSupport::TestCase
       @client.delete_entity_alias(@entity_name, @alias_name, auth_path)
     end
     assert_match /no such alias/, err.message
+
+    # confirm 1 aliases
+    entity =  @client.read_entity(@entity_name)
+    assert_equal 1, entity.data[:aliases].size
   end
 
   test ".assign_policy creates valid entity" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,14 +13,16 @@ module ActiveSupport
 
     # Helper methods
     def jwt_authorized
-      data = {"sub"=>"john.doe@example.com", "name"=>"John Doe", "iat"=>1516239022,
-               "groups"=>["group1", "group2"], "aud"=>"astral"}
-      JWT.encode(data, Config[:jwt_signing_key])
+      @@authorized_token ||= JWT.encode(@@authorized_data, Config[:jwt_signing_key])
     end
 
     def jwt_unauthorized
-      data = {"sub"=>"application_name", "common_name"=>"example.com", "ip_sans"=>"10.0.1.100"}
-      JWT.encode(data, "bad_secret")
+      @@unauthorized_token ||= JWT.encode(@@unauthorized_data, "bad_secret")
     end
+
+    private
+    @@authorized_data   = { "sub"=>"john.doe@example.com", "name"=>"John Doe", "iat"=>1516239022,
+                           "groups"=>[ "group1", "group2" ], "aud"=>"astral" }
+    @@unauthorized_data = { "sub"=>"application_name", "common_name"=>"example.com", "ip_sans"=>"10.0.1.100" }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,11 +13,14 @@ module ActiveSupport
 
     # Helper methods
     def jwt_authorized
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huLmRvZUBleGFtcGxlLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZ3JvdXBzIjpbImdyb3VwMSIsImdyb3VwMiJdLCJhdWQiOiJhc3RyYWwifQ.tfRLXmE_eq-piP88_clwPWrYfMAQbCJAeZQI6OFxZSI"
+      data = {"sub"=>"john.doe@example.com", "name"=>"John Doe", "iat"=>1516239022,
+               "groups"=>["group1", "group2"], "aud"=>"astral"}
+      JWT.encode(data, Config[:jwt_signing_key])
     end
 
     def jwt_unauthorized
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhcHBsaWNhdGlvbl9uYW1lIiwiY29tbW9uX25hbWUiOiJleGFtcGxlLmNvbSIsImlwX3NhbnMiOiIxMC4wLjEuMTAwIn0.gEUyaZcARiBQNq2RUwZU0MdFXqthyo_oSQ8DAgKvxCs"
+      data = {"sub"=>"application_name", "common_name"=>"example.com", "ip_sans"=>"10.0.1.100"}
+      JWT.encode(data, "bad_secret")
     end
   end
 end


### PR DESCRIPTION
The following test was failing about 2% of the test runs.
```
OidcTest#test_aliases_contain_initial_users_email [test/lib/clients/oidc_test.rb:23]:
Expected nil to be truthy.
```

## Can't have two entities with same alias/auth-path

Multiple entities can't have the same entity alias.  If an alias gets assigned to an entity, and then to a second entity, it gets removed from the first.  (Which is why alias's should be unique across a single auth method.)

That was the problem with this test failure; there were multiple entities with the same entity alias, ("john.doe@example.com").

The error would occur when the alias got taken away by the second entity in the middle of the test of the first.

The fix was simply to change the "initial_user_email" config parameter to "test2024@example.com"

In addition, to debug the problem, I had to decode the jwt_authorized token.  I decided to leave it decoded, as a class variable in test_helper.rb, and recompute it each start up. (It seems clearer that way.)

## Fixed incompletely specified aliases

In debugging this problem, I also noticed a different, related problem.  I was only using the alias name to specify the alias, but multiple aliases can have the same name if they have different auth paths.

I have fixed this so that alias access now requires both the name and auth-path

## Ticket
PR fixes this ticket: https://github.com/G-Research/astral/issues/73
