### PR TITLE
GROSS-1358: SHA-pin GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3 
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Dev Container task
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: ghcr.io/astral-devcontainer
           cacheFrom: ghcr.io/astral-devcontainer
@@ -30,15 +30,15 @@ jobs:
             bundle install
 
       - name: Lint code for consistent style
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: ghcr.io/astral-devcontainer
           cacheFrom: ghcr.io/astral-devcontainer
           push: never
           runCmd: bin/rubocop -f github
-  
+
       - name: Run brakeman
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: ghcr.io/astral-devcontainer
           cacheFrom: ghcr.io/astral-devcontainer
@@ -46,7 +46,7 @@ jobs:
           runCmd: bin/brakeman --no-pager
 
       - name: Run tests
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: ghcr.io/astral-devcontainer
           cacheFrom: ghcr.io/astral-devcontainer
@@ -54,7 +54,7 @@ jobs:
           runCmd: bin/rails test
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: screenshots
@@ -71,7 +71,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Compute repo name
         id: repo


### PR DESCRIPTION
## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments).

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` ref can be silently rewritten upstream or by a compromised account and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing `# <version>` comment keeps the pin human-readable.

## Notes

- Dependabot already scans the `github-actions` ecosystem here, so no Dependabot change is needed — it will keep these pins up to date.
- Actions pinned to their current major's SHA — a pin, not a version bump.