### PR TITLE
Fix devcontainer CI: drop stale yarn apt source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,11 @@ RUN su vscode -c "/usr/local/rvm/bin/rvm fix-permissions"
 # The value is a comma-separated list of allowed domains 
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
 
+# Drop the stale yarn apt source shipped by the base image: its signing key
+# was rotated (NO_PUBKEY 62D54FD4003F6525), which breaks `apt-get update`.
+# yarn itself is already installed in the base image, so the source isn't needed.
+RUN find /etc/apt -name '*.list' -exec sed -i '/dl.yarnpkg.com/d' {} +
+
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends postgresql-client emacs-nox

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
         "forwardPorts": [3000, 5432, 8200, 8300],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-        "postCreateCommand": "bundle install && rake oidc_provider:configure && rake db:setup",
+        "postCreateCommand": "bundle install && bundle exec rake oidc_provider:configure && bundle exec rake db:setup",
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION

Two small fixes so the dev container builds and sets up in CI again (`build_test` was failing).